### PR TITLE
build: run CI workflow on `main`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
     paths-ignore:
       - README.md
       - docs/**


### PR DESCRIPTION
As `master` has been laid to rest.

Part of https://github.com/getsops/community/issues/16